### PR TITLE
Centralized to either docker-compose environment or env_file

### DIFF
--- a/common/common.sh
+++ b/common/common.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 set -e
 
-export AWS_ACCESS_KEY_ID="${LOCI_S3_ACCESS_KEY_ID}"
-export AWS_SECRET_ACCESS_KEY="${LOCI_S3_SECRET_ACCESS_KEY}"
-
 SCRIPT_HOME=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
-#import env vars to shell
+#import env vars to shell this is required in additon to env_file in some cases where variables need to be remapped
 export $(grep -v '^#' ${SCRIPT_HOME}/common.env | sed '/^$/d' | xargs -0)

--- a/docker/harvest/asgs/README.md
+++ b/docker/harvest/asgs/README.md
@@ -3,7 +3,7 @@ To run the harvest, simple pick the `harvest[year].sh` and run it from the asgs 
 The scripts pull confguration from the /common/common.sh script. This sets a bunch of common variables to ensure all the 
 containers are consistent with each other.
 
-The scripts will upload the harvest files to the AWS automatically, and as such need credentials. By default the common.sh will look for: 
+The scripts will upload the harvest files to the AWS automatically, and as such need credentials. By default the will following environment variables are expected: 
 
 `LOCI_S3_ACCESS_KEY_ID`
 `LOCI_S3_SECRET_ACCESS_KEY`

--- a/docker/harvest/asgs/docker-compose.base.yml
+++ b/docker/harvest/asgs/docker-compose.base.yml
@@ -6,8 +6,8 @@ services:
             context: .
             dockerfile: Dockerfile
         environment: 
-            - AWS_ACCESS_KEY_ID
-            - AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID=${LOCI_S3_ACCESS_KEY_ID}
+            - AWS_SECRET_ACCESS_KEY=${LOCI_S3_SECRET_ACCESS_KEY}
             - S3_BUCKET
             - S3_REGION
             - S3_PATH=${S3_DATASET_PATH}


### PR DESCRIPTION
Local docker AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY defined via LOCI_S3_ACCESS_KEY_ID and LOCI_S3_SECRET_ACCESS_KEY follow the same pattern as other environment variables that need passing through with different names. 