### PR TITLE
Small load enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker/linksets/assets/

--- a/docker/linksets/.env
+++ b/docker/linksets/.env
@@ -3,5 +3,7 @@
 DATABASE_URL=postgis
 S3_GEOFABRIC_PATH=/geofabric_2-1/HR_Catchments_GDB_V2_1_1.zip
 ASGS_MB_WFS_URL=https://geo.abs.gov.au/arcgis/services/ASGS2016/MB/MapServer/WFSServer
+S3_ASGS_2016_MB_PATH=/asgs2016/mb_2016_all_shape.zip
+ASGS_MB_LOCAL_NAME_PREFIX="mb_2016_all_shape"
 CONTACT_NAME="Ashley Sommer"
 CONTACT_EMAIL="Ashley.Sommer@csiro.au"

--- a/docker/linksets/README.md
+++ b/docker/linksets/README.md
@@ -8,6 +8,16 @@ Requires environment variables configured in `../../common/common.sh` and in `./
 
 additionally valid `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be set prior to run
 
+## Optional
+
+Optionally set LOAD_LIMIT to test the link build process by loading a limited subset of input data
+
 ## Running
 
-Run with `start.sh`
+Run with `start.sh` to execute the default workflow
+
+Modify docker-compose.yml to swap to the `tail -f...` command to enable manual execution then docker-compose exec linksets to execute manual commands in the `/app/` directory.
+
+### Linkset upload
+
+To upload a new version of the asgs 2016 mb data from WFS to S3 execute `cd /app/linksets/mb2cc && python preload_asgs_wfs.py` in the linksets container

--- a/docker/linksets/mb2cc/linksets_builder.py
+++ b/docker/linksets/mb2cc/linksets_builder.py
@@ -11,6 +11,9 @@ s3_source_data_path = utils.fail_or_getenv('S3_SOURCE_DATA_PATH')
 s3_geofabric_path = utils.fail_or_getenv('S3_GEOFABRIC_PATH')
 s3_asgs_2016_mb_path = utils.fail_or_getenv('S3_ASGS_2016_MB_PATH')
 asgs_mb_wfs_url = utils.fail_or_getenv('ASGS_MB_WFS_URL')
+# check that AWS keys are defined for command line aws s3 calls
+utils.fail_or_getenv('AWS_ACCESS_KEY_ID')
+utils.fail_or_getenv('AWS_SECRET_ACCESS_KEY')
 asgs_2016_local_name_prefix = "mb_2016_all_shape"
 
 
@@ -62,10 +65,9 @@ def get_s3_assets(local_file_name_save_to, s3_bucket, s3_path):
     '''
     if not os.path.exists('../assets'):
         os.makedirs('../assets')
-    if not os.path.exists('../assets/{}'.format(local_file_name_save_to)):
-        run_command(['aws', 's3', 'cp', 's3://{}{}'.format(s3_bucket, s3_path), '../assets/', '--no-sign-request'])
-        with zipfile.ZipFile('../assets/{}.zip'.format(local_file_name_save_to), 'r') as zip_ref:
-            zip_ref.extractall('../assets')
+    run_command(['aws', 's3', 'cp', 's3://{}{}'.format(s3_bucket, s3_path), '../assets/'])
+    with zipfile.ZipFile('../assets/{}.zip'.format(local_file_name_save_to), 'r') as zip_ref:
+        zip_ref.extractall('../assets')
 
 
 def get_geofabric_assets():

--- a/docker/linksets/mb2cc/linksets_builder.py
+++ b/docker/linksets/mb2cc/linksets_builder.py
@@ -1,27 +1,37 @@
 import zipfile
 import os
-import subprocess
-from subprocess import CalledProcessError
 import logging
-import boto3
-from botocore import UNSIGNED
-from botocore.client import Config
 import utils
-import os
+from utils import run_command
 logging.basicConfig(level=logging.DEBUG)
 
+LIMIT_LOAD = utils.fail_or_getenv('LIMIT_LOAD', warn_only=True)
 s3_bucket = utils.fail_or_getenv('S3_BUCKET')
 s3_source_data_path = utils.fail_or_getenv('S3_SOURCE_DATA_PATH')
 s3_geofabric_path = utils.fail_or_getenv('S3_GEOFABRIC_PATH')
+s3_asgs_2016_mb_path = utils.fail_or_getenv('S3_ASGS_2016_MB_PATH')
 asgs_mb_wfs_url = utils.fail_or_getenv('ASGS_MB_WFS_URL')
+asgs_2016_local_name_prefix = "mb_2016_all_shape"
 
-def run_command(command_line_array):
+
+def load_via_ogr(source_data, define_target_geometry_type='MULTIPOLYGON', limit=LIMIT_LOAD):
     '''
-    Utility for running commands and logging outputs
+    Loads spatial data into postgis
+    :param source_data: source data for ogr2ogr to load into postgres
+    :param define_target_geometry_type: target geometry type see ogr2ogr documentation, defaults to MULTIPOLYGON
+    :param limit: limit the number of rows loaded, used for testing, defaults to None which is no limit
     '''
-    output = ''
-    output = subprocess.check_output(command_line_array, universal_newlines=True)
-    logging.info(output)
+    limit_args = []
+    if limit is not None:
+        limit_args = ["-limit", limit]
+
+    target_geometry_args = []
+    if define_target_geometry_type is not None:
+        target_geometry_args = ["-nlt", define_target_geometry_type]
+
+    run_command(["ogr2ogr", "-f", "PostgreSQL", "PG:host=postgis port=5432 dbname=mydb user=postgres password=password",
+                source_data, "-skipfailures", "-overwrite", "-progress"] + target_geometry_args + limit_args + ["--config", "PG_USE_COPY", "YES"])
+
 
 def prepare_database():
     '''
@@ -31,29 +41,42 @@ def prepare_database():
     run_command(["psql", "--host", "postgis", "--user", "postgres", "-c", "DROP DATABASE IF EXISTS mydb;"])
     run_command(["psql", "--host", "postgis", "--user", "postgres", "-c", "CREATE DATABASE mydb;"])
     run_command(["psql", "--host", "postgis", "--user", "postgres", "-d", "mydb", 
-    "-c", "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;"])
+                "-c", "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;"])
+
 
 def load_asgs_mb():
     '''
     Load ASGS Mesh Blocks into PostGIS
     Note: `-nlt MULTIPOLYGON` is specified here, because by default it will ingest as MULTISURFACE, which doesn't work well for our use-case.
-    There will be some errors when it tries to import mb:mb_pt, because it POINTS don't work with MULTIPOLYGON layer types. Ignore this. We don't use mb_pt
+    There will be some errors when it tries to import mb_mb_pt, because it POINTS don't work with MULTIPOLYGON layer types. Ignore this. We don't use mb_pt
     All ASGS coords are in crs EPSG:3857, this needs to be transformed to albers (EPSG:3577) in the sql query in order to do constant-area intersections with catchments 
     eg: ST_Transform(shape, 3577)
     '''
     logging.info("Loading asgs meshblocks")
-    run_command(["ogr2ogr", "-f", "PostgreSQL", "PG:host=postgis port=5432 dbname=mydb user=postgres password=password", 
-        "WFS:{}".format(asgs_mb_wfs_url), "-skipfailures", "-overwrite", "-progress", "-nlt",
-        "MULTIPOLYGON", "--config", "PG_USE_COPY", "YES"])
+    load_via_ogr("../assets/{}/MB_MB.shp".format(asgs_2016_local_name_prefix))
+
+
+def get_s3_assets(local_file_name_save_to, s3_bucket, s3_path):
+    '''
+    Download zipped s3 assets and unzip them 
+    '''
+    if not os.path.exists('../assets'):
+        os.makedirs('../assets')
+    if not os.path.exists('../assets/{}'.format(local_file_name_save_to)):
+        run_command(['aws', 's3', 'cp', 's3://{}{}'.format(s3_bucket, s3_path), '../assets/', '--no-sign-request'])
+        with zipfile.ZipFile('../assets/{}.zip'.format(local_file_name_save_to), 'r') as zip_ref:
+            zip_ref.extractall('../assets')
+
 
 def get_geofabric_assets():
     logging.info("Downloading geofabric spatial data")
-    if not os.path.exists('../assets'):
-        os.makedirs('../assets')
-    if not os.path.exists('../assets/HR_Catchments_GDB_V2_1_1.zip'):
-        run_command(['aws', 's3', 'cp', 's3://{}{}{}'.format(s3_bucket, s3_source_data_path, s3_geofabric_path), '../assets/', '--no-sign-request'])
-        with zipfile.ZipFile('../assets/HR_Catchments_GDB_V2_1_1.zip', 'r') as zip_ref:
-            zip_ref.extractall('../assets')
+    get_s3_assets('HR_Catchments_GDB_V2_1_1', s3_bucket, s3_source_data_path + s3_geofabric_path)
+
+
+def get_meshblock_assets():
+    logging.info("Downloading asgs 2016 spatial data")
+    get_s3_assets(asgs_2016_local_name_prefix, s3_bucket, s3_source_data_path + s3_asgs_2016_mb_path)
+
 
 def load_geofabric_catchments():
     '''
@@ -63,8 +86,7 @@ def load_geofabric_catchments():
     eg: ST_GeomFromWKB(shape, 4326). Then we need to convert it to albers (EPSG:3577) in order to do constant-area intersections with meshblocks.
     '''
     logging.info("Loading geofabric catchments")
-    run_command(["ogr2ogr", "-f", "PostgreSQL", "PG:host=postgis port=5432 dbname=mydb user=postgres password=password", 
-        "../assets/HR_Catchments_GDB/HR_Catchments.gdb", "-skipfailures", "-overwrite", "-progress", "--config", "PG_USE_COPY", "YES"])
+    load_via_ogr("../assets/HR_Catchments_GDB/HR_Catchments.gdb", define_target_geometry_type=None)
 
 
 def harmonize_crs_albers():
@@ -73,8 +95,8 @@ def harmonize_crs_albers():
     '''
     logging.info("Harmonizing coordinates to the albers reference system")
     harmonize_crs_sql = """
-    ALTER TABLE public.\"mb:mb\" ADD COLUMN geom_3577 geometry(Geometry,3577);
-    UPDATE public.\"mb:mb\" SET geom_3577 = ST_MakeValid(ST_Transform(shape,3577));
+    ALTER TABLE public.\"mb_mb\" ADD COLUMN geom_3577 geometry(Geometry,3577);
+    UPDATE public.\"mb_mb\" SET geom_3577 = ST_MakeValid(ST_Transform(wkb_geometry,3577));
     ALTER TABLE public.\"ahgfcontractedcatchment\" ADD COLUMN geom_3577 geometry(Geometry,3577);
     UPDATE public.\"ahgfcontractedcatchment\" SET geom_3577 = ST_Transform(ST_MakeValid(ST_GeomFromEWKB(shape)),3577);
     """
@@ -87,28 +109,29 @@ def create_geometry_indexes():
     '''
     logging.info("Creating Geometry Indexes")
     create_geometry_indexes_sql = """
-    CREATE INDEX mb_geom_3577_gix ON public.\"mb:mb\" USING GIST (geom_3577);
+    CREATE INDEX mb_geom_3577_gix ON public.\"mb_mb\" USING GIST (geom_3577);
     CREATE INDEX cc_geom_3577_gix ON public.\"ahgfcontractedcatchment\" USING GIST (geom_3577);
     """
     run_command(["psql", "--host", "postgis", "--user",
                  "postgres", "-d", "mydb", "-c", create_geometry_indexes_sql])
 
+
 def create_intersections():
     logging.info("Calculating intersecting mb and cc")
     create_intersection_sql = """
-CREATE MATERIALIZED VIEW mbintersectcc_mv AS
-SELECT mb.mb_code_2016, ca.hydroid, ST_Intersection(mb.geom_3577, ca.geom_3577) as i
-FROM public.\"ahgfcontractedcatchment\" as ca
-INNER JOIN public.\"mb:mb\" as mb ON mb.geom_3577 && ca.geom_3577 -- the && specifies an indexed bounding box lookup
-WHERE ST_IsValid(ca.geom_3577) AND ST_IsValid(mb.geom_3577) AND ST_Intersects(mb.geom_3577, ca.geom_3577)
-ORDER BY mb.mb_code_2016 ASC;
-CREATE MATERIALIZED VIEW ccintersectmb_mv AS
-SELECT ca.hydroid, mb.mb_code_2016, ST_Intersection(ca.geom_3577, mb.geom_3577) as i
-FROM public.\"mb:mb\" as mb
-INNER JOIN public.\"ahgfcontractedcatchment\" as ca ON ca.geom_3577 && mb.geom_3577 -- the && specifies an indexed bounding box lookup
-WHERE ST_IsValid(ca.geom_3577) AND ST_IsValid(mb.geom_3577) AND ST_Intersects(ca.geom_3577, mb.geom_3577)
-ORDER BY ca.hydroid ASC;
-"""
+    CREATE MATERIALIZED VIEW mbintersectcc_mv AS
+    SELECT mb.mb_code_20, ca.hydroid, ST_Intersection(mb.geom_3577, ca.geom_3577) as i
+    FROM public.\"ahgfcontractedcatchment\" as ca
+    INNER JOIN public.\"mb_mb\" as mb ON mb.geom_3577 && ca.geom_3577 -- the && specifies an indexed bounding box lookup
+    WHERE ST_IsValid(ca.geom_3577) AND ST_IsValid(mb.geom_3577) AND ST_Intersects(mb.geom_3577, ca.geom_3577)
+    ORDER BY mb.mb_code_20 ASC;
+    CREATE MATERIALIZED VIEW ccintersectmb_mv AS
+    SELECT ca.hydroid, mb.mb_code_20, ST_Intersection(ca.geom_3577, mb.geom_3577) as i
+    FROM public.\"mb_mb\" as mb
+    INNER JOIN public.\"ahgfcontractedcatchment\" as ca ON ca.geom_3577 && mb.geom_3577 -- the && specifies an indexed bounding box lookup
+    WHERE ST_IsValid(ca.geom_3577) AND ST_IsValid(mb.geom_3577) AND ST_Intersects(ca.geom_3577, mb.geom_3577)
+    ORDER BY ca.hydroid ASC;
+    """
     run_command(["psql", "--host", "postgis", "--user",
                  "postgres", "-d", "mydb", "-c", create_intersection_sql])
 
@@ -118,47 +141,48 @@ def create_indexes():
     '''
     logging.info("Creating Geometry Indexes")
     create_geometry_indexes_sql = """
-    CREATE INDEX mbintersects_mb_code_idx ON public.\"mbintersectccareas\" USING GIST (mb_code_2016);
+    CREATE INDEX mbintersects_mb_code_idx ON public.\"mbintersectccareas\" USING GIST (mb_code_20);
     CREATE INDEX mbintersects_hydroid_idx ON public.\"ccintersectsmbareas\" USING GIST (hydroid);
-    CREATE INDEX _mb_code_idx ON public.\"mbintersectcc_mv\" USING GIST (mb_code_2016);
+    CREATE INDEX _mb_code_idx ON public.\"mbintersectcc_mv\" USING GIST (mb_code_20);
     CREATE INDEX mbintersects_hydroid_idx ON public.\"mbintersectcc_mv\" USING GIST (hydroid);
     """
     run_command(["psql", "--host", "postgis", "--user",
                  "postgres", "-d", "mydb", "-c", create_geometry_indexes_sql])
 
+
 def create_intersections_areas():
     logging.info("Calculating intersecting area for mb and cc")
     create_intersection_areas_sql = """
-CREATE VIEW mbintersectccareas AS
-SELECT s.mb_code_2016, s.hydroid, s.mb_area, s.cc_area, s.i_area, (s.i_area / s.mb_area) as mb_proportion, (s.i_area / s.cc_area) as cc_proportion, s.geomcollection FROM (
-    SELECT mv.mb_code_2016,
+    CREATE VIEW mbintersectccareas AS
+    SELECT s.mb_code_20, s.hydroid, s.mb_area, s.cc_area, s.i_area, (s.i_area / s.mb_area) as mb_proportion, (s.i_area / s.cc_area) as cc_proportion, s.geomcollection FROM (
+    SELECT mv.mb_code_20,
            mv.hydroid,
            ST_Area(mb.geom_3577)                         as mb_area,
            ST_Area(ca.geom_3577)                         as cc_area,
            ST_Area(mv.i)                                 as i_area,
            ST_Collect(ARRAY[ca.geom_3577, mb.geom_3577, mv.i]) as geomcollection
     FROM mbintersectcc_mv as mv
-    INNER JOIN public.\"mb:mb\" as mb ON mb.mb_code_2016 = mv.mb_code_2016
+    INNER JOIN public.\"mb_mb\" as mb ON mb.mb_code_20 = mv.mb_code_20
     INNER JOIN public.\"ahgfcontractedcatchment\" as ca ON ca.hydroid = mv.hydroid
-) as s;
-CREATE VIEW ccintersectmbareas AS
-SELECT s.hydroid, s.mb_code_2016, s.cc_area, s.mb_area, s.i_area, (s.i_area / s.cc_area) as cc_proportion, (s.i_area / s.mb_area) as mb_proportion, s.geomcollection FROM (
+    ) as s;
+    CREATE VIEW ccintersectmbareas AS
+    SELECT s.hydroid, s.mb_code_20, s.cc_area, s.mb_area, s.i_area, (s.i_area / s.cc_area) as cc_proportion, (s.i_area / s.mb_area) as mb_proportion, s.geomcollection FROM (
     SELECT mv.hydroid,
-           mv.mb_code_2016,
+           mv.mb_code_20,
            ST_Area(ca.geom_3577)                         as cc_area,
            ST_Area(mb.geom_3577)                         as mb_area,
            ST_Area(mv.i)                                 as i_area,
            ST_Collect(ARRAY[mb.geom_3577, ca.geom_3577, mv.i]) as geomcollection
     FROM ccintersectmb_mv as mv
     INNER JOIN public.\"ahgfcontractedcatchment\" as ca ON ca.hydroid = mv.hydroid
-    INNER JOIN public.\"mb:mb\" as mb ON mb.mb_code_2016 = mv.mb_code_2016
-) as s;
-"""
+    INNER JOIN public.\"mb_mb\" as mb ON mb.mb_code_20 = mv.mb_code_20
+    ) as s;
+    """
     run_command(["psql", "--host", "postgis", "--user",
                  "postgres", "-d", "mydb", "-c", create_intersection_areas_sql])
 
+
 def find_bad_meshblocks():
-    logging.info("Finding bad meshblocks (unused at the moment)")
     '''
     Find bad mesblocks
     Meshblocks smaller than an specified area and meshblock proportion (is that amount in the meshblock when it intersects?)
@@ -167,20 +191,21 @@ def find_bad_meshblocks():
     Mesblocks where intersecting area smaller than a specified area 
     and catchment proportion (maybe the amount intersecting that is in the catchment) is larger than a small ratio 
     '''
+    logging.info("Finding bad meshblocks (unused at the moment)")
     find_bad_meshblocks_sql = """
     CREATE MATERIALIZED VIEW bad_meshblocks as
-    SELECT mb.mb_code_2016, mb.hydroid FROM mbintersectccareas as mb
+    SELECT mb.mb_code_20, mb.hydroid FROM mbintersectccareas as mb
     WHERE mb.mb_area < 1100.0 and ((mb_proportion >= 0.010)or(cc_proportion >= 0.010)) and i_area <= 50.0;
     """
     run_command(["psql", "--host", "postgis", "--user",
                  "postgres", "-d", "mydb", "-c", find_bad_meshblocks_sql])
 
 def create_classifier_views():
-    logging.info("Classifying ambiguous overlapping meshblocks thresholds")
     '''
     annotate meshblocks and cc to indicate whether they are considered truely overlapping or close enough to be within
     when they intersect 
     '''
+    logging.info("Classifying ambiguous overlapping meshblocks thresholds")
     create_classifier_views_sql = """
     CREATE VIEW mbintersectccareas_classify AS
     SELECT mb.*, mb_proportion >= 0.010 as is_overlaps, mb_proportion >=0.990 as is_within
@@ -193,10 +218,12 @@ def create_classifier_views():
     run_command(["psql", "--host", "postgis", "--user",
                  "postgres", "-d", "mydb", "-c", create_classifier_views_sql])
 
+
 if __name__ == "__main__":
     prepare_database()
-    load_asgs_mb()
     get_geofabric_assets()
+    get_meshblock_assets()
+    load_asgs_mb()
     load_geofabric_catchments()
     harmonize_crs_albers()
     create_geometry_indexes()

--- a/docker/linksets/mb2cc/linksets_triples_builder.py
+++ b/docker/linksets/mb2cc/linksets_triples_builder.py
@@ -122,11 +122,11 @@ def do_overlaps():
     con = pg.connect("host={} port=5432 dbname=mydb user=postgres password=password".format(database_url))
     cur = con.cursor("cur1")
     command = """\
-    SELECT mb.mb_code_2016, cc.hydroid, mb.mb_area, cc.cc_area, mb.i_area, mb.is_overlaps, cc.is_overlaps, mb.is_within, cc.is_within 
+    SELECT mb.mb_code_20, cc.hydroid, mb.mb_area, cc.cc_area, mb.i_area, mb.is_overlaps, cc.is_overlaps, mb.is_within, cc.is_within 
     FROM public.\"mbintersectccareas_classify\" as mb
-    INNER JOIN public.\"ccintersectmbareas_classify\" as cc on mb.mb_code_2016 = cc.mb_code_2016 and mb.hydroid = cc.hydroid
+    INNER JOIN public.\"ccintersectmbareas_classify\" as cc on mb.mb_code_20 = cc.mb_code_20 and mb.hydroid = cc.hydroid
     WHERE (mb.is_overlaps or cc.is_overlaps) and (not mb.is_within) and (not cc.is_within)
-    -- ORDER BY mb.mb_code_2016;
+    -- ORDER BY mb.mb_code_20;
     """
     c = 0
     intersection_iter = 0
@@ -163,9 +163,9 @@ def do_withins():
     con = pg.connect("host={} dbname=mydb user=postgres password=password".format(database_url))
     cur = con.cursor("cur2")
     command = """\
-    SELECT mb.mb_code_2016, cc.hydroid, mb.is_within, cc.is_within
+    SELECT mb.mb_code_20, cc.hydroid, mb.is_within, cc.is_within
     FROM public.\"mbintersectccareas_classify\" as mb
-    INNER JOIN public.\"ccintersectmbareas_classify\" as cc on mb.mb_code_2016 = cc.mb_code_2016 and mb.hydroid = cc.hydroid
+    INNER JOIN public.\"ccintersectmbareas_classify\" as cc on mb.mb_code_20 = cc.mb_code_20 and mb.hydroid = cc.hydroid
     WHERE mb.is_within or cc.is_within
     """
     c = 0

--- a/docker/linksets/mb2cc/preload_asgs_wfs.py
+++ b/docker/linksets/mb2cc/preload_asgs_wfs.py
@@ -1,0 +1,42 @@
+import zipfile
+import os
+import utils
+import logging
+import boto3
+logging.basicConfig(level=logging.DEBUG)
+
+utils.fail_or_getenv('AWS_ACCESS_KEY_ID')
+utils.fail_or_getenv('AWS_SECRET_ACCESS_KEY')
+s3_bucket = utils.fail_or_getenv('S3_BUCKET')
+s3_source_data_path = utils.fail_or_getenv('S3_SOURCE_DATA_PATH')
+s3_asgs_2016_mb_path = utils.fail_or_getenv('S3_ASGS_2016_MB_PATH')
+asgs_mb_wfs_url = utils.fail_or_getenv('ASGS_MB_WFS_URL')
+s3_region_name = utils.fail_or_getenv('S3_REGION')
+local_name_prefix = utils.fail_or_getenv("ASGS_MB_LOCAL_NAME_PREFIX")
+
+
+def dump_local_asgs_mb():
+    '''
+    Dump WFS meshblocks to a local shapefile 
+    '''
+    logging.info("Dumping meshblocks from WFS service")
+    source_data = "WFS:{}".format(asgs_mb_wfs_url)
+    utils.run_command(["ogr2ogr", local_name_prefix, source_data])
+    with zipfile.ZipFile('{}.zip'.format(local_name_prefix), 'w') as myzip:
+        for folderName, subfolders, filenames in os.walk('./{}'.format(local_name_prefix)):
+            for filename in filenames:
+                myzip.write(os.path.join(folderName, filename))
+
+
+def upload_asgs_mb_s3():
+    '''
+    Upload the asgs file created to s3 for later use 
+    '''
+    logging.info("Uploading meshblocks file to S3")
+    s3_client = boto3.client('s3', region_name=s3_region_name)
+    s3_client.upload_file('./'+local_name_prefix+'.zip', s3_bucket, (s3_source_data_path + s3_asgs_2016_mb_path)[1:])
+
+
+if __name__ == '__main__':
+    dump_local_asgs_mb()
+    upload_asgs_mb_s3()

--- a/docker/linksets/mb2cc/utils.py
+++ b/docker/linksets/mb2cc/utils.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import logging
-
+logging.basicConfig(level=logging.DEBUG)
 
 def run_command(command_line_array):
     '''

--- a/docker/linksets/mb2cc/utils.py
+++ b/docker/linksets/mb2cc/utils.py
@@ -1,7 +1,24 @@
 import os
-def fail_or_getenv(env_var_name):
+import subprocess
+import logging
+
+
+def run_command(command_line_array):
+    '''
+    Utility for running commands and logging outputs
+    '''
+    output = ''
+    logging.debug(command_line_array)
+    output = subprocess.check_output(command_line_array, universal_newlines=True)
+    logging.info(output)
+
+
+def fail_or_getenv(env_var_name, warn_only=False):
     env_value = os.getenv(env_var_name)
     if env_value is None:
+        if warn_only:
+            logging.warn("Environment variable {env_var_name} is not defined".format(env_var_name=env_var_name))
+            return None
         raise Exception("Environment variable {env_var_name} must be defined".format(env_var_name=env_var_name))
     else:
         return env_value


### PR DESCRIPTION
This is a collection of commits that begin the process of refactoring linksets to be more generic, it:

1. refactors linkset load for mb <> cc so that a LOAD_LIMIT can be specified to limit the number of rows loaded into the database. This can speed up testing a lot by reducing the local iteration time, it should not modify default behaviour.
2. substitutes direct asgs mb WFS access in `ogr2ogr` for download of a cache of that data from s3, additional scripts are provided for creating or updating that cache copy, column names have been renamed to match new column names and table names that are an artifact of storing the WFS data in a shape file in the cache. Note that names are in the process of being made generic in a branch off of this one so non ideal column names shouldn't be a big deal. 
3. Generally cleans up some of the python dependencies (I ran a linter)