### PR TITLE
Rr cc intermediate

### DIFF
--- a/docker/linksets/.env
+++ b/docker/linksets/.env
@@ -2,6 +2,7 @@
 #These values dont have to be the same as what is in the dockerfile
 DATABASE_URL=postgis
 S3_GEOFABRIC_PATH=/geofabric_2-1/HR_Catchments_GDB_V2_1_1.zip
+S3_GEOFABRIC_RR_PATH=/geofabric_2-1/HR_Regions_GDB_V2_1_1.zip
 ASGS_MB_WFS_URL=https://geo.abs.gov.au/arcgis/services/ASGS2016/MB/MapServer/WFSServer
 S3_ASGS_2016_MB_PATH=/asgs2016/mb_2016_all_shape.zip
 ASGS_MB_LOCAL_NAME_PREFIX="mb_2016_all_shape"

--- a/docker/linksets/mb2cc/linksets_rr_cc_builder.py
+++ b/docker/linksets/mb2cc/linksets_rr_cc_builder.py
@@ -1,0 +1,39 @@
+import linksets_builder
+import utils
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+s3_geofabric_rr_path = utils.fail_or_getenv('S3_GEOFABRIC_RR_PATH')
+
+def get_riverregion_assets():
+    logging.info("Downloading geofabric riverregion spatial data")
+    linksets_builder.get_s3_assets('HR_Regions_GDB_V2_1_1', linksets_builder.s3_bucket, linksets_builder.s3_source_data_path + s3_geofabric_rr_path)
+
+def load_geofabric_riverregions():
+    '''
+    Loads Geofabric river regions into PostGIS
+    '''
+    logging.info("Loading geofabric River Regions")
+
+    linksets_builder.load_via_ogr("../assets/HR_Regions_GDB/HR_Regions.gdb", "from", source_data_table="RiverRegion", define_target_geometry_type=None)
+    utils.alter_column_name("from", "hydroid", "hydroid_rr")
+    from_id_column = "hydroid_rr"
+    return from_id_column
+
+if __name__ == "__main__":
+    #Generic preparation logic
+    linksets_builder.prepare_database()
+
+    #Specific meshblock and catchment logic TODO: This and generic logic will be seperated further in future refactors
+    linksets_builder.get_geofabric_assets()
+    get_riverregion_assets()
+    load_from_data = load_geofabric_riverregions
+    load_to_data = linksets_builder.load_geofabric_catchments
+    from_id_column = load_from_data()
+    to_id_column = load_to_data()
+
+    # Generic linksets builder logic
+    linksets_builder.create_geometry_indexes()
+    linksets_builder.create_intersections(from_id_column, to_id_column)
+    linksets_builder.create_intersections_areas(from_id_column, to_id_column)
+    linksets_builder.create_classifier_views()

--- a/docker/linksets/mb2cc/linksets_rr_cc_triples_builder.py
+++ b/docker/linksets/mb2cc/linksets_rr_cc_triples_builder.py
@@ -1,0 +1,21 @@
+import linksets_triples_builder
+import utils
+
+if __name__ == "__main__":
+    database_url = utils.fail_or_getenv('DATABASE_URL')
+    contact_name = utils.fail_or_getenv('CONTACT_NAME')
+    contact_email = utils.fail_or_getenv('CONTACT_EMAIL')
+    header_description = """This LOC-I Project Linkset relates River Regions to Contracted Catchments"""
+    header_title = "River Regions to Contracted Catchments Linkset"
+    to_id_column = "hydroid"
+    from_id_column = "hydroid_rr"
+    subjects_target = "http://linked.data.gov.au/dataset/geofabric"
+    objects_target = "http://linked.data.gov.au/dataset/geofabric"
+    from_prefix = "http://linked.data.gov.au/dataset/geofabric/riverregion/"
+    to_prefix = "http://linked.data.gov.au/dataset/geofabric/contractedcatchment/"
+    provenance_comment = "The method used to classify river region and Contracted Catchment relationships"
+    linksets_triples_builder.database_url = database_url
+    linksets_triples_builder.do_withins(from_id_column, to_id_column)
+    linksets_triples_builder.do_overlaps(from_id_column, to_id_column)
+    linksets_triples_builder.generate_header(header_description, header_title, contact_name, contact_email, from_prefix, to_prefix, subjects_target, objects_target, provenance_comment)
+    linksets_triples_builder.concat_files("ls_rr16cc.ttl")

--- a/docker/linksets/mb2cc/utils.py
+++ b/docker/linksets/mb2cc/utils.py
@@ -12,6 +12,15 @@ def run_command(command_line_array):
     output = subprocess.check_output(command_line_array, universal_newlines=True)
     logging.info(output)
 
+def alter_column_name(table_name, column_name, new_column_name):
+    '''
+    Change the name of a column in a table
+    '''
+    create_intersection_sql = """ALTER TABLE \"{table_name}\" RENAME \"{column_name}\" TO \"{new_column_name}\";"""\
+        .format(table_name=table_name, column_name=column_name, new_column_name=new_column_name)
+    run_command(["psql", "--host", "postgis", "--user",
+                 "postgres", "-d", "mydb", "-c", create_intersection_sql])
+
 
 def fail_or_getenv(env_var_name, warn_only=False):
     env_value = os.getenv(env_var_name)


### PR DESCRIPTION
This merges an application of the generalized database load back into generalized_database_load. This branch rr_cc_intermediate has been tested to the extent that it successfully generates a `ls_rr16cc.ttl` and I have spot checked withins relationships described by the file finding that the sparql

```
select * where { 
	<http://linked.data.gov.au/dataset/geofabric/contractedcatchment/12400035> ?p <http://linked.data.gov.au/dataset/geofabric/riverregion/9400263> .
} 
```
indicates a relationship present in the graph database also described in the generated `ls_rr16cc.ttl`.  My aim is to have a subsequent pull request go back from `generalize_database_load` to master. This will then form the basis of a generalized polygon to polygon linkset builder with an included example of customization beyond the default `mb to cc`. Additional work needs to be done on future branches to refactor the high level structure of files to better modularize common vs specific functionality.