### PR TITLE
Adding a dockerfile that is able to be built from repo basedir

### DIFF
--- a/docker/cache/Dockerfile-atbasedir
+++ b/docker/cache/Dockerfile-atbasedir
@@ -1,0 +1,46 @@
+FROM ubuntu:18.04
+
+#MAINTAINER Ivan Subotic "ivan.subotic@unibas.ch"
+MAINTAINER Shane Seaton "shane.seaton@csiro.au"
+
+# Silence debconf messages
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install.
+RUN \
+  sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+  apt-get -qq update && \
+  apt-get -y install \
+    byobu curl git htop man vim wget unzip \
+    openjdk-8-jdk && \
+  rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
+ENV APP_HOME='/app'
+ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+ENV GRAPHDB_HOME="/graphdb"
+ENV GRAPHDB_ZIP="${APP_HOME}/graphdb.zip"
+ENV REPO_CONFIG="${APP_HOME}/repo-config.ttl"
+ENV GRAPHDB_SOURCE=${GRAPHDB_SOURCE:-"${APP_HOME}/cachedata"}
+# Set GraphDB Max and Min Heap size (must be less than available RAM)
+ENV GDB_HEAP_SIZE="${GDB_HEAP_SIZE:-1g}"
+
+WORKDIR ${APP_HOME}
+
+RUN wget https://loci-assets.s3-ap-southeast-2.amazonaws.com/script-resources/graph-cache/graphdb-free-8.10.0-dist.zip -O ${GRAPHDB_ZIP}
+# COPY ./graphdb-free-8.10.0-dist.zip ${GRAPHDB_ZIP}
+RUN unzip ${GRAPHDB_ZIP} -d ${APP_HOME}/graphdb && \
+    mv ${APP_HOME}/graphdb/graphdb-* ${GRAPHDB_HOME} && \
+    rm ${GRAPHDB_ZIP}    
+
+COPY ./docker/cache/resources/graphdb.properties ${GRAPHDB_HOME}/conf/graphdb.properties
+COPY ./docker/cache/resources/repo-config.ttl ${REPO_CONFIG}
+COPY ./docker/cache/resources/download-data.sh .
+COPY ./docker/cache/resources/pre-condition-files/* pre-condition-files/
+
+#Build the Cache
+COPY ./docker/cache/resources/build-cache.sh ${APP_HOME}
+WORKDIR ${APP_HOME}
+EXPOSE 7200
+
+CMD ["/bin/bash", "-c", "${APP_HOME}/build-cache.sh"]


### PR DESCRIPTION
For the purposes of automated builds from the basedir, e.g. docker hub, it expects a Dockerfile location relative to the basedir of the repo and a `docker build` execution from that basedir. Currently the build fails because resources are relative to the `docker/cache` dir.

This PR proposes a copy of the current cache dockerfile but with the specified paths relative to the basedir.