### PR TITLE
Local build v2

### DIFF
--- a/docker/cache/resources/pre-condition-files/010_delete_buggy_linkset.sparql
+++ b/docker/cache/resources/pre-condition-files/010_delete_buggy_linkset.sparql
@@ -1,0 +1,13 @@
+PREFIX loci: <http://linked.data.gov.au/def/loci#>
+PREFIX void: <http://rdfs.org/ns/void#>
+DELETE {
+    ?linkset void:subjectsTarget ?subjectsTarget .
+    ?linkset void:objectsTarget ?objectsTarget .
+}
+WHERE {
+        ?linkset a loci:Linkset .
+        ?linkset void:subjectsTarget ?subjectsTarget .
+        ?linkset void:objectsTarget ?objectsTarget .
+    FILTER(?subjectsTarget = ?objectsTarget)
+    FILTER(?linkset = <http://linked.data.gov.au/dataset/mb16cc>)
+}

--- a/docker/cache/resources/pre-condition-files/011_add_fixed_linkset.sparql
+++ b/docker/cache/resources/pre-condition-files/011_add_fixed_linkset.sparql
@@ -1,0 +1,10 @@
+PREFIX loci: <http://linked.data.gov.au/def/loci#>
+PREFIX void: <http://rdfs.org/ns/void#>
+INSERT {
+    ?linkset void:subjectsTarget <http://linked.data.gov.au/dataset/asgs2016> .
+    ?linkset void:objectsTarget <http://linked.data.gov.au/dataset/geofabric> .
+}
+WHERE {
+        ?linkset a loci:Linkset .        
+    FILTER(?linkset = <http://linked.data.gov.au/dataset/mb16cc>)
+}

--- a/docker/cache/resources/pre-condition-files/012_remove_ced_within_ste.sparql
+++ b/docker/cache/resources/pre-condition-files/012_remove_ced_within_ste.sparql
@@ -1,0 +1,10 @@
+PREFIX asgs: <http://linked.data.gov.au/def/asgs#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+DELETE {
+   ?ced geo:sfWithin ?ste .
+}
+WHERE { 
+	?ced a asgs:CommonwealthElectoralDivision .
+    ?ced geo:sfWithin ?ste .   
+    FILTER(strstarts(str(?ste), "http://linked.data.gov.au/dataset/asgs2016/stateorterritory/") )
+} 

--- a/docker/cache/resources/pre-condition-files/013_remove_ste_contains_ced.sparql
+++ b/docker/cache/resources/pre-condition-files/013_remove_ste_contains_ced.sparql
@@ -1,0 +1,10 @@
+PREFIX asgs: <http://linked.data.gov.au/def/asgs#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+DELETE {
+    ?ste geo:sfContains ?ced  . 
+}  
+WHERE { 
+	?ced a asgs:CommonwealthElectoralDivision .
+    ?ste geo:sfContains ?ced  .   
+    FILTER(strstarts(str(?ste), "http://linked.data.gov.au/dataset/asgs2016/stateorterritory/") )
+} 

--- a/docker/cache/startup.sh
+++ b/docker/cache/startup.sh
@@ -24,14 +24,22 @@ then
         
         unset FORCE_REFRESH
         unset SKIP_DOWNLOAD 
+    elif [ "$1" == "--debug" ]
+    then
+	echo "debug"
     else
-        echo "--rebuild is the only valid option to this script"
+        echo "--rebuild or --local-build is the only valid option to this script"
         exit 1
     fi
 fi
 
-#start the service with a restart paremeter set.
-docker-compose -f docker-compose.yml -f docker-compose.restart.yml up -d --build --force-recreate
+#start the service with a restart parameter set.
+if [[ -n "$1" ]] && [[ "$1" == "--local-build" ]]
+then
+   docker-compose -f docker-compose.local.yml -f docker-compose.restart.yml up -d --build --force-recreate
+else 
+   docker-compose -f docker-compose.yml -f docker-compose.restart.yml up -d --build --force-recreate
+fi
 
 #Use this to see the logs if needed
 #docker-compose logs -f

--- a/docker/cache/startup.sh
+++ b/docker/cache/startup.sh
@@ -19,7 +19,7 @@ then
         export FORCE_REFRESH=1
         echo "Skipping download phase and building"
         # run and wait for exit (build)
-        echo "docker-compose -f docker-compose.local.yml up --build --force-recreate --abort-on-container-exit"
+        echo "docker-compose -f docker-compose.local.yml up --force-recreate --abort-on-container-exit"
         docker-compose -f docker-compose.local.yml up --force-recreate --abort-on-container-exit
         
         unset FORCE_REFRESH

--- a/docker/cache/startup.sh
+++ b/docker/cache/startup.sh
@@ -20,7 +20,7 @@ then
         echo "Skipping download phase and building"
         # run and wait for exit (build)
         echo "docker-compose -f docker-compose.local.yml up --build --force-recreate --abort-on-container-exit"
-        docker-compose -f docker-compose.local.yml up --build --force-recreate --abort-on-container-exit
+        docker-compose -f docker-compose.local.yml up --force-recreate --abort-on-container-exit
         
         unset FORCE_REFRESH
         unset SKIP_DOWNLOAD 


### PR DESCRIPTION
This PR adds additional pre-conditioning steps as part of the automated cache deployment (rather than manually adding them). These have been tested via pyloci test scripts and tests pass.

It also modifies the start script slightly so that if `local-build` is specified, then the docker image is used rather than building from scratch. This is useful in a deployment scenario with no connection to the public web.